### PR TITLE
Fix/disable wq setprovider

### DIFF
--- a/controller/stats_reporter.go
+++ b/controller/stats_reporter.go
@@ -91,7 +91,15 @@ func init() {
 			stats.UnitSeconds,
 		),
 	}
+
 	_ = wp
+	/*
+		disable workqueue.SetProvider temporary
+		workqueue.SetProvider only set once.
+		Due to some weird init order issues, `knative.dev/pkg/controller` always init firstly instead of `sigs.k8s.io/controller-runtime/pkg/metrics`.
+		it will conflict to sigs.k8s.io/controller-runtime/pkg/metrics/workqueue.go and cause method in controller-runtime to be invalid
+		and no client-go metrics will be reported when we use controller-runtime framework
+	*/
 	// workqueue.SetProvider(wp)
 
 	cp := &metrics.ClientProvider{

--- a/controller/stats_reporter.go
+++ b/controller/stats_reporter.go
@@ -27,7 +27,6 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	kubemetrics "k8s.io/client-go/tools/metrics"
-	"k8s.io/client-go/util/workqueue"
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/metrics/metricskey"
 )
@@ -92,7 +91,8 @@ func init() {
 			stats.UnitSeconds,
 		),
 	}
-	workqueue.SetProvider(wp)
+	_ = wp
+	// workqueue.SetProvider(wp)
 
 	cp := &metrics.ClientProvider{
 		Latency: stats.Float64(


### PR DESCRIPTION
disable workqueue.SetProvider temporary

workqueue.SetProvider only set once.
Due to some weird init order issues, `knative.dev/pkg/controller` always init firstly instead of `sigs.k8s.io/controller-runtime/pkg/metrics`.
it will conflict to sigs.k8s.io/controller-runtime/pkg/metrics/workqueue.go and cause method in controller-runtime to be invalid
and no client-go metrics will be reported when we use controller-runtime framework