### PR TITLE
fix: vuln 0512

### DIFF
--- a/.build/build.yaml
+++ b/.build/build.yaml
@@ -33,7 +33,7 @@ spec:
         - name: container-image-tag
           value: v$(tasks.oss-version.results.oss-version)-$(tasks.oss-version.results.commit-short-id)
         - name: tool-image
-          value: registry.alauda.cn:60080/devops/builder-go:latest
+          value: registry.alauda.cn:60080/devops/github/builder-go:latest
     - name: image-scan
       timeout: 30m
       retries: 0


### PR DESCRIPTION
Switch tool-image from `devops/builder-go:latest` to `devops/github/builder-go:latest` to pick up Go 1.26.3.

The `devops/builder-go:latest` mirror still ships Go 1.25.7, which leaves 15 stdlib CVEs unfixed (incl. Critical CVE-2025-68121). The `devops/github/builder-go:latest` mirror was rebuilt 2026-05-08 and now ships Go 1.26.3.

Follows the same pattern as eventing PR #13 (`fix: vuln 1205`).

Part of the v3.20.10 vuln-fix sweep for `knative-operator-bundle`.